### PR TITLE
support all or nothing

### DIFF
--- a/cmd/tparagen/main.go
+++ b/cmd/tparagen/main.go
@@ -22,7 +22,7 @@ func main() {
 	kingpin.HelpFlag.Short('h')
 
 	if err := tparagen.Run(os.Stdout, os.Stderr, strings.Split(*ignoreDirectories, ","), *minGoVersion); err != nil {
-		fmt.Println(err.Error())
+		os.Stderr.WriteString(err.Error())
 		os.Exit(1)
 	}
 

--- a/process.go
+++ b/process.go
@@ -17,7 +17,7 @@ const (
 	testPrefix            = "Test"
 )
 
-func Process(filename string, src []byte, needFixLoopVar bool) ([]byte, error) {
+func GenerateTParallel(filename string, src []byte, needFixLoopVar bool) ([]byte, error) {
 	fs := token.NewFileSet()
 
 	f, err := parser.ParseFile(fs, filename, src, parser.ParseComments)

--- a/process_test.go
+++ b/process_test.go
@@ -938,7 +938,7 @@ func TestFunctionRangeMissingCallToParallel(t *testing.T) {
 		t.Run(tt.testCase, func(t *testing.T) {
 			t.Parallel()
 
-			got, err := Process("./testdata/t/t_test.go", []byte(tt.src), tt.needFixLoopVar)
+			got, err := GenerateTParallel("./testdata/t/t_test.go", []byte(tt.src), tt.needFixLoopVar)
 			if err != nil {
 				t.Fatal(err.Error())
 			}

--- a/tparagen.go
+++ b/tparagen.go
@@ -128,7 +128,9 @@ func (t *tparagen) run() error {
 
 		if err := os.Rename(tmpPath, origPath); err != nil {
 			// TODO: logging
-			t.errStream.Write([]byte(fmt.Sprintf("failed to rename %s to %s. %v\n", tmpPath, origPath, err)))
+			if _, err := t.errStream.Write([]byte(fmt.Sprintf("failed to rename %s to %s. %v\n", tmpPath, origPath, err))); err != nil {
+				return false
+			}
 		}
 
 		return true

--- a/tparagen.go
+++ b/tparagen.go
@@ -85,7 +85,7 @@ func (t *tparagen) run() error {
 			return fmt.Errorf("cannot read %s. %w", path, err)
 		}
 
-		got, err := Process(path, b, t.needFixLoopVar)
+		got, err := GenerateTParallel(path, b, t.needFixLoopVar)
 		if err != nil {
 			return fmt.Errorf("error occurred in Process(). %w", err)
 		}

--- a/tparagen.go
+++ b/tparagen.go
@@ -81,11 +81,6 @@ func (t *tparagen) run() error {
 		}
 
 		if !bytes.Equal(b, got) {
-			if len(t.dest) != 0 && t.in != t.dest {
-				if err := t.writeOtherPath(t.in, t.dest, path, got); err != nil {
-					return fmt.Errorf("error occurred in triteOtherPath(). %w", err)
-				}
-			}
 			if _, err := f.WriteAt(got, 0); err != nil {
 				return fmt.Errorf("error occurred in writeAt(). %w", err)
 			}
@@ -93,39 +88,6 @@ func (t *tparagen) run() error {
 
 		return nil
 	})
-}
-
-func (t *tparagen) writeOtherPath(in, dist, path string, got []byte) error {
-	p, err := filepath.Rel(in, path)
-	if err != nil {
-		return err
-	}
-
-	distabs, err := filepath.Abs(dist)
-	if err != nil {
-		return err
-	}
-
-	dp := filepath.Join(distabs, p)
-	dpd := filepath.Dir(dp)
-
-	if _, err := os.Stat(dpd); os.IsNotExist(err) {
-		if err := os.Mkdir(dpd, 0777); err != nil {
-			return fmt.Errorf("create dir failed at %q: %w", dpd, err)
-		}
-	}
-
-	f, err := os.OpenFile(dp, os.O_RDWR|os.O_CREATE, 0644)
-	if err != nil {
-		return nil
-	}
-	defer f.Close()
-
-	if _, err = f.Write(got); err != nil {
-		return fmt.Errorf("write file failed at %q: %w", dp, err)
-	}
-
-	return nil
 }
 
 func (t *tparagen) skipDir(p string) bool {

--- a/tparagen.go
+++ b/tparagen.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	"github.com/saracen/walker"
 )
@@ -47,7 +48,15 @@ type tparagen struct {
 	needFixLoopVar       bool
 }
 
+// run() traverses from the root node, and when it finds the target test file, it will process the assignment of a concurrency marker.
+// The contents of each processed file are written to a temporary file.
+// After all scans are complete, rewrite the original file with the contents of each temporary file.
 func (t *tparagen) run() error {
+	// Information of files to be modified
+	// key: original file path, value: temporary file path
+	// walker.Walk() may execute concurrently, so sync.Map is used.
+	var tempFiles sync.Map
+
 	err := walker.Walk(t.in, func(path string, info fs.FileInfo) error {
 		if info.IsDir() && t.skipDir(path) {
 			return filepath.SkipDir
@@ -62,6 +71,15 @@ func (t *tparagen) run() error {
 			return fmt.Errorf("cannot open %s. %w", path, err)
 		}
 		defer f.Close()
+
+		tmpf, err := os.CreateTemp("", "temp_")
+		if err != nil {
+			return fmt.Errorf("failed to create temp file for %s. %w", path, err)
+		}
+
+		defer tmpf.Close()
+		tempFiles.Store(path, tmpf.Name())
+
 		b, err := io.ReadAll(f)
 		if err != nil {
 			return fmt.Errorf("cannot read %s. %w", path, err)
@@ -80,8 +98,44 @@ func (t *tparagen) run() error {
 
 		return nil
 	})
+	// If an error occurs, remove all temporary files
+	if err != nil {
+		tempFiles.Range(func(_, p any) bool {
+			path, ok := p.(string)
+			if !ok {
+				return false
+			}
 
-	return err
+			// Remove temporary files
+			os.Remove(path)
+
+			return true
+		})
+
+		return err
+	}
+
+	// Replace the original file with the temporary file if all writes are successful
+	tempFiles.Range(func(key, value any) bool {
+		origPath, ok := key.(string)
+		if !ok {
+			return false
+		}
+
+		tmpPath, ok := value.(string)
+		if !ok {
+			return false
+		}
+
+		if err := os.Rename(tmpPath, origPath); err != nil {
+			// TODO: logging
+			t.errStream.Write([]byte(fmt.Sprintf("failed to rename %s to %s. %v\n", tmpPath, origPath, err)))
+		}
+
+		return true
+	})
+
+	return nil
 }
 
 func (t *tparagen) skipDir(p string) bool {

--- a/tparagen.go
+++ b/tparagen.go
@@ -28,7 +28,6 @@ func Run(outStream, errStream io.Writer, ignoreDirectories []string, minGoVersio
 
 	t := &tparagen{
 		in:         defaultTargetDir,
-		dest:       "",
 		outStream:  outStream,
 		errStream:  errStream,
 		ignoreDirs: ignoreDirs,
@@ -42,7 +41,7 @@ func Run(outStream, errStream io.Writer, ignoreDirectories []string, minGoVersio
 }
 
 type tparagen struct {
-	in, dest             string
+	in                   string
 	outStream, errStream io.Writer
 	ignoreDirs           []string
 	needFixLoopVar       bool

--- a/tparagen.go
+++ b/tparagen.go
@@ -48,20 +48,12 @@ type tparagen struct {
 }
 
 func (t *tparagen) run() error {
-	return walker.Walk(t.in, func(path string, info fs.FileInfo) error {
+	err := walker.Walk(t.in, func(path string, info fs.FileInfo) error {
 		if info.IsDir() && t.skipDir(path) {
 			return filepath.SkipDir
 		}
 
-		if info.IsDir() {
-			return nil
-		}
-
-		if filepath.Ext(path) != ".go" {
-			return nil
-		}
-
-		if !strings.HasSuffix(filepath.Base(path), "_test.go") {
+		if info.IsDir() || filepath.Ext(path) != ".go" || !strings.HasSuffix(filepath.Base(path), "_test.go") {
 			return nil
 		}
 
@@ -88,6 +80,8 @@ func (t *tparagen) run() error {
 
 		return nil
 	})
+
+	return err
 }
 
 func (t *tparagen) skipDir(p string) bool {


### PR DESCRIPTION
This pull request includes several changes to improve error handling, enhance concurrency, all-or-nothing feature in the `tparagen` tool.

### Error Handling Improvements:
* [`cmd/tparagen/main.go`](diffhunk://#diff-9a2791bf4141afdd15c51a5de192278de8e8ca9d6b430c090b58e737f328e00aL25-R25): Changed error output from `fmt.Println` to `os.Stderr.WriteString` to ensure errors are written to the standard error stream.

### Function Renaming:
* [`process.go`](diffhunk://#diff-837cc8a2afa55dfd32c6ff6d135feb979c715f582a4ee3b6250288e747f84463L20-R20): Renamed the `Process` function to `GenerateTParallel` to better reflect its purpose.
* [`process_test.go`](diffhunk://#diff-5542bcbdd7b17472f45e0c1258394d7d04cfce1878f29e32229fee8ec1c19858L941-R941): Updated test cases to use the renamed `GenerateTParallel` function.

### Concurrency Enhancements:
* [`tparagen.go`](diffhunk://#diff-c0d36d18ff64fcf5892da6ec60a13457ff4679cb6d3b71cbe75efba631fcbe97R11): Added `sync.Map` to handle concurrent file processing and ensure thread safety. [[1]](diffhunk://#diff-c0d36d18ff64fcf5892da6ec60a13457ff4679cb6d3b71cbe75efba631fcbe97R11) [[2]](diffhunk://#diff-c0d36d18ff64fcf5892da6ec60a13457ff4679cb6d3b71cbe75efba631fcbe97L44-R64)
* [`tparagen.go`](diffhunk://#diff-c0d36d18ff64fcf5892da6ec60a13457ff4679cb6d3b71cbe75efba631fcbe97R73-R136): Modified the `run` method to use temporary files for intermediate processing and safely replace original files after processing.

### Code Cleanup:
* [`tparagen.go`](diffhunk://#diff-c0d36d18ff64fcf5892da6ec60a13457ff4679cb6d3b71cbe75efba631fcbe97L30): Removed the unused `dest` field from the `tparagen` struct.