### PR TITLE
Fix: use actual receiver name when inserting Parallel()

### DIFF
--- a/process.go
+++ b/process.go
@@ -132,7 +132,7 @@ func GenerateTParallel(filename string, src []byte, needFixLoopVar bool) ([]byte
 							funcArg := n.Args[1]
 							// insert parallel helper method
 							if fun, ok := funcArg.(*ast.FuncLit); ok {
-								tpStmt := buildTParallelStmt(fun.Body.Lbrace)
+								tpStmt := buildTParallelStmt(fun.Body.Lbrace, innerTestVar)
 								fun.Body.List = append([]ast.Stmt{tpStmt}, fun.Body.List...)
 							}
 						}
@@ -189,7 +189,7 @@ func GenerateTParallel(filename string, src []byte, needFixLoopVar bool) ([]byte
 
 		// Check if the main test calls Parallel().
 		if !testHasParallel && !testHasSetenv {
-			tpStmt := buildTParallelStmt(funcDecl.Body.Lbrace)
+			tpStmt := buildTParallelStmt(funcDecl.Body.Lbrace, testVar)
 			funcDecl.Body.List = append([]ast.Stmt{tpStmt}, funcDecl.Body.List...)
 		}
 
@@ -216,7 +216,8 @@ func GenerateTParallel(filename string, src []byte, needFixLoopVar bool) ([]byte
 								funcArg := c.Args[1]
 								// insert parallel helper method
 								if fun, ok := funcArg.(*ast.FuncLit); ok {
-									tpStmt := buildTParallelStmt(fun.Body.Lbrace)
+									innerTestVar := getRunCallbackParameterName(c)
+									tpStmt := buildTParallelStmt(fun.Body.Lbrace, innerTestVar)
 									fun.Body.List = append([]ast.Stmt{tpStmt}, fun.Body.List...)
 									isInsertedTparallel = true
 								}
@@ -385,14 +386,14 @@ func methodSetEnvIsCalledInMethodRun(node ast.Node, testVar string) bool {
 	return methodSetenvCalled
 }
 
-// build `t.Parallel()` statement to pos location specified in the argument.
-func buildTParallelStmt(pos token.Pos) *ast.ExprStmt {
+// build `<testVar>.Parallel()` statement to pos location specified in the argument.
+func buildTParallelStmt(pos token.Pos, testVar string) *ast.ExprStmt {
 	return &ast.ExprStmt{
 		X: &ast.CallExpr{
 			Fun: &ast.SelectorExpr{
 				X: &ast.Ident{
 					NamePos: pos,
-					Name:    "t",
+					Name:    testVar,
 				},
 				Sel: &ast.Ident{
 					NamePos: pos,

--- a/process_test.go
+++ b/process_test.go
@@ -27,6 +27,32 @@ func NoTestFunction() {}
 `,
 		},
 		{
+			testCase:       "insert Parallel using the actual receiver name when it is not t",
+			needFixLoopVar: true,
+			src: `package t
+
+import "testing"
+
+func TestFunctionMissingParallelReceiverNotT(_t *testing.T) {
+	_t.Run("1", func(inner *testing.T) {
+		fmt.Println("1")
+	})
+}
+`,
+			want: `package t
+
+import "testing"
+
+func TestFunctionMissingParallelReceiverNotT(_t *testing.T) {
+	_t.Parallel()
+	_t.Run("1", func(inner *testing.T) {
+		inner.Parallel()
+		fmt.Println("1")
+	})
+}
+`,
+		},
+		{
 			testCase:       "looks like a test but is with param",
 			needFixLoopVar: true,
 			src: `package t
@@ -143,7 +169,7 @@ import "testing"
 func TestFunctionMissingParallelAllTests(t *testing.T) {
 	t.Parallel()
 	t.Run("1", func(x *testing.T) {
-		t.Parallel()
+		x.Parallel()
 		fmt.Println("1")
 	})
 	t.Run("2", func(t *testing.T) {


### PR DESCRIPTION
## Overview

Fixes #18

Fixes a bug where `tparagen` always inserted `t.Parallel()` even when the `*testing.T` parameter of a test function or subtest was named something other than `t` (e.g. `_t`), generating code that would not compile.

```go
func TestXXX(_t *testing.T) {
}
```
↓ Before: inserted `t.Parallel()` (undefined) → After: inserts `_t.Parallel()`

## Cause

`buildTParallelStmt` hardcoded the receiver name of the inserted `Parallel()` call to `"t"`.

## Changes

- `process.go`: Added a `testVar string` parameter to `buildTParallelStmt` and updated the three call sites to pass the correct variable name
  - Main test function → `testVar`
  - `t.Run` subtest → `innerTestVar`
  - Subtest inside a range → `getRunCallbackParameterName(c)`
- `process_test.go`: Added test cases covering the issue scenario. Corrected incorrect expectations in existing fixtures (`t.Parallel()` for `func(x *testing.T)`) to `x.Parallel()`

## Testing

`go test ./...` all passing